### PR TITLE
Make SandboxKeys overridable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ lazy val root = (project in file(".")).enablePlugins(ConductRSandbox)
 To run the sandbox environment use the following task:
 
 ```scala
-conductr-sandbox-run
+conductrSandboxRun
 ```
 
 > Note that the ConductR cluster will take a few seconds to become available and so any initial command that you send to it may not work immediately.
 
 Given the above you will then have a ConductR process running in the background (there will be an initial download cost for Docker to download the `conductr/conductr-dev` image from the public Docker registry).
 
-To stop the cluster use the `conductr-sandbox-stop` task.
+To stop the cluster use the `conductrSandboxStop` task.
 
 If the `sbt-conductr` plugin is enabled for your project then the `conduct info` and other `conduct` commands can communicate with the Docker cluster managed by the sandbox. To set this up type the following command within the sbt console:
 

--- a/src/sbt-test/sbt-conductr-sandbox/ports/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports/build.sbt
@@ -1,0 +1,25 @@
+import org.scalatest.Matchers._
+
+lazy val root = (project in file(".")).enablePlugins(ConductRSandbox)
+
+name := "simple-test"
+
+version := "0.1.0-SNAPSHOT"
+
+// ConductR Sandbox
+SandboxKeys.ports := Set(1111, 2222)
+
+val checkPorts = taskKey[Unit]("Check that the specified ports are exposed to docker.")
+
+checkPorts := {
+  val content = s"docker port cond-0".!!
+  val expectedLines = Set(
+    """9004/tcp -> 0.0.0.0:9004""",
+    """9005/tcp -> 0.0.0.0:9005""",
+    """9006/tcp -> 0.0.0.0:9006""",
+    """1111/tcp -> 0.0.0.0:1101""",
+    """2222/tcp -> 0.0.0.0:2202"""
+  )
+
+  expectedLines.foreach(line => content should include(line))
+}

--- a/src/sbt-test/sbt-conductr-sandbox/ports/project/build.properties
+++ b/src/sbt-test/sbt-conductr-sandbox/ports/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.8

--- a/src/sbt-test/sbt-conductr-sandbox/ports/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-conductr-sandbox" % sys.props("project.version"))
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"

--- a/src/sbt-test/sbt-conductr-sandbox/ports/test
+++ b/src/sbt-test/sbt-conductr-sandbox/ports/test
@@ -1,0 +1,5 @@
+> conductr-sandbox-run
+
+> checkPorts
+
+> conductr-sandbox-stop


### PR DESCRIPTION
So far the SanboxKeys couldn't be overriden by the `build.sbt` because they have been defined in Global scope. Also the commands `sandboxControlServer`, `conductrSandboxRun` and `conductrSandboxStop` were not accessible from the sbt console of the app which included the plugin.

This PR fixes this issue by moving the configuration to the project settings.
