### PR TITLE
Add debug port setting to debug a bundle

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,8 @@ ScalariformKeys.preferences := ScalariformKeys.preferences.value
   .setPreference(DoubleIndentClassDeclaration, true)
   .setPreference(PreserveDanglingCloseParenthesis, true)
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-bundle" % "1.0.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-bundle"        % "1.0.0")
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.0.0")
 
 releaseSettings
 ReleaseKeys.versionBump := sbtrelease.Version.Bump.Minor

--- a/sbt-conductr-sandbox-tester/build.sbt
+++ b/sbt-conductr-sandbox-tester/build.sbt
@@ -10,9 +10,11 @@ BundleKeys.nrOfCpus := 1.0
 BundleKeys.memory := 64.MiB
 BundleKeys.diskSpace := 10.MB
 BundleKeys.roles := Set("web-server")
+BundleKeys.startCommand := Seq("-Xms1G")
 
 BundleKeys.configurationName := "frontend"
 
 SandboxKeys.image in Global := "conductr/conductr"
 SandboxKeys.nrOfContainers in Global := 3
 SandboxKeys.ports in Global := Set(9999)
+SandboxKeys.debugPort := 5432

--- a/src/sbt-test/sbt-conductr-sandbox/basic/test
+++ b/src/sbt-test/sbt-conductr-sandbox/basic/test
@@ -1,7 +1,7 @@
-> conductr-sandbox-run
+> sandbox run
 
 > checkConductRIsRunning
 
-> conductr-sandbox-stop
+> sandbox stop
 
 > checkConductRIsStopped

--- a/src/sbt-test/sbt-conductr-sandbox/ports-basic/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-basic/build.sbt
@@ -1,0 +1,75 @@
+import org.scalatest.Matchers._
+import ByteConversions._
+
+lazy val root = (project in file(".")).enablePlugins(ConductRPlugin, ConductRSandbox)
+
+name := "ports-basic"
+
+version := "0.1.0-SNAPSHOT"
+
+// ConductR bundle keys
+BundleKeys.nrOfCpus := 1.0
+BundleKeys.memory := 64.MiB
+BundleKeys.diskSpace := 10.MB
+BundleKeys.endpoints := Map("other" -> Endpoint("http", services = Set(URI("http://:9001/other-service"))))
+
+// ConductR sandbox keys
+SandboxKeys.ports in Global := Set(1111, 2222)
+SandboxKeys.debugPort := 5432
+
+/**
+ * Check ports after 'sandbox run' command
+ */
+val checkPortsWithRun = taskKey[Unit]("Check that the specified ports are exposed to docker. Debug port should not be exposed.")
+checkPortsWithRun := {
+  val content = s"docker port cond-0".!!
+  val expectedLines = Set(
+    """9004/tcp -> 0.0.0.0:9004""",
+    """9005/tcp -> 0.0.0.0:9005""",
+    """9006/tcp -> 0.0.0.0:9006""",
+    """1111/tcp -> 0.0.0.0:1101""",
+    """2222/tcp -> 0.0.0.0:2202""",
+    """9001/tcp -> 0.0.0.0:9001"""
+  )
+
+  expectedLines.foreach(line => content should include(line))
+}
+
+/**
+ * Check bundle conf after 'sandbox run' and 'bundle:dist'
+ */
+val checkRunStartCommand = taskKey[Unit]("Check the start-command in bundle.conf. jvm-debug should not be part of it.")
+checkRunStartCommand := {
+  val contents = IO.read((target in Bundle).value / "tmp" / "bundle.conf")
+  val expectedContents = """start-command    = ["ports-basic-0.1.0-SNAPSHOT/bin/ports-basic", "-J-Xms67108864", "-J-Xmx67108864"]""".stripMargin
+  contents should include(expectedContents)
+}
+
+/**
+ * Check ports after 'sandbox debug'
+ */
+val checkPortsWithDebug = taskKey[Unit]("Check that the specified ports are exposed to docker. Debug port should be exposed.")
+checkPortsWithDebug := {
+  val content = s"docker port cond-0".!!
+  val expectedLines = Set(
+    """9004/tcp -> 0.0.0.0:9004""",
+    """9005/tcp -> 0.0.0.0:9005""",
+    """9006/tcp -> 0.0.0.0:9006""",
+    """1111/tcp -> 0.0.0.0:1101""",
+    """2222/tcp -> 0.0.0.0:2202""",
+    """5432/tcp -> 0.0.0.0:5402""",
+    """9001/tcp -> 0.0.0.0:9001"""
+  )
+
+  expectedLines.foreach(line => content should include(line))
+}
+
+/**
+ * Check bundle conf after 'sandbox debug' and 'bundle:dist'
+ */
+val checkDebugStartCommand = taskKey[Unit]("Check the start-command in bundle.conf. jvm-debug should be part of it.")
+checkDebugStartCommand := {
+  val contents = IO.read((target in Bundle).value / "tmp" / "bundle.conf")
+  val expectedContents = """start-command    = ["ports-basic-0.1.0-SNAPSHOT/bin/ports-basic", "-J-Xms67108864", "-J-Xmx67108864", "-jvm-debug 5432"]""".stripMargin
+  contents should include(expectedContents)
+}

--- a/src/sbt-test/sbt-conductr-sandbox/ports-basic/project/build.properties
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-basic/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.8

--- a/src/sbt-test/sbt-conductr-sandbox/ports-basic/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-basic/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-conductr-sandbox" % sys.props("project.version"))
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.0.0")
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"

--- a/src/sbt-test/sbt-conductr-sandbox/ports-basic/test
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-basic/test
@@ -1,0 +1,19 @@
+> sandbox run
+
+> checkPortsWithRun
+
+> bundle:dist
+
+> checkRunStartCommand
+
+> clean
+
+> sandbox debug
+
+> checkPortsWithDebug
+
+> bundle:dist
+
+> checkDebugStartCommand
+
+> sandbox stop

--- a/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/build.sbt
@@ -1,0 +1,72 @@
+import org.scalatest.Matchers._
+import ByteConversions._
+
+name := "ports-multi-module"
+version := "0.1.0-SNAPSHOT"
+
+// ConductR global keys
+SandboxKeys.ports in Global := Set(1111, 2222)
+SandboxKeys.image in Global := "conductr/conductr"
+SandboxKeys.nrOfContainers in Global := 2
+
+lazy val common = (project in file("modules/common"))
+  .enablePlugins(ConductRSandbox)
+  .settings(
+    SandboxKeys.debugPort := 8888
+  )
+
+lazy val frontend = (project in file("modules/frontend"))
+  .enablePlugins(ConductRPlugin, ConductRSandbox)
+  .dependsOn(common)
+  .settings(
+    BundleKeys.nrOfCpus := 1.0,
+    BundleKeys.memory := 64.MiB,
+    BundleKeys.diskSpace := 50.MiB,
+    BundleKeys.roles := Set("frontend"),
+    BundleKeys.endpoints := Map("frontend" -> Endpoint("http", services = Set(URI("http://:9000")))),
+    SandboxKeys.debugPort := 9999
+  )
+
+lazy val backend = (project in file("modules/backend"))
+  .enablePlugins(ConductRPlugin, ConductRSandbox)
+  .dependsOn(common)
+  .settings(
+    BundleKeys.nrOfCpus := 1.0,
+    BundleKeys.memory := 128.MiB,
+    BundleKeys.diskSpace := 50.MiB,
+    BundleKeys.roles := Set("backend"),
+    BundleKeys.endpoints := Map("backend" -> Endpoint("http", services = Set(URI("http://:2551")))),
+    SandboxKeys.debugPort := 2999
+  )
+
+val checkDockerContainers = taskKey[Unit]("Check that the specified ports are exposed to docker.")
+
+checkDockerContainers := {
+  // cond-0
+  val contentCond0 = s"docker port cond-0".!!
+  val expectedLinesCond0 = Set(
+    """9004/tcp -> 0.0.0.0:9004""",
+    """9005/tcp -> 0.0.0.0:9005""",
+    """9006/tcp -> 0.0.0.0:9006""",
+    """1111/tcp -> 0.0.0.0:1101""",
+    """2222/tcp -> 0.0.0.0:2202""",
+    """8888/tcp -> 0.0.0.0:8808""",
+    """9999/tcp -> 0.0.0.0:9909""",
+    """2999/tcp -> 0.0.0.0:2909"""
+  )
+  expectedLinesCond0.foreach(line => contentCond0 should include(line))
+
+  // cond-1
+  val contentCond1 = s"docker port cond-1".!!
+  val expectedLinesCond1 = Set(
+    """9004/tcp -> 0.0.0.0:9014""",
+    """9005/tcp -> 0.0.0.0:9015""",
+    """9006/tcp -> 0.0.0.0:9016""",
+    """1111/tcp -> 0.0.0.0:1111""",
+    """2222/tcp -> 0.0.0.0:2212""",
+    """8888/tcp -> 0.0.0.0:8818""",
+    """9999/tcp -> 0.0.0.0:9919""",
+    """2999/tcp -> 0.0.0.0:2919"""
+  )
+  expectedLinesCond1.foreach(line => contentCond1 should include(line))
+}

--- a/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/modules/backend/src/main/scala/BackendApp.scala
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/modules/backend/src/main/scala/BackendApp.scala
@@ -1,0 +1,3 @@
+object BackendApp extends App {
+  println("Execute backend app.")
+}

--- a/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/modules/common/src/main/scala/CommonApp.scala
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/modules/common/src/main/scala/CommonApp.scala
@@ -1,0 +1,3 @@
+object CommonApp extends App {
+  println("Execute common app.")
+}

--- a/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/modules/frontend/src/main/scala/FrontendApp.scala
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/modules/frontend/src/main/scala/FrontendApp.scala
@@ -1,0 +1,3 @@
+object FrontendApp extends App {
+  println("Execute frontend app.")
+}

--- a/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/project/build.properties
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.8

--- a/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-conductr-sandbox" % sys.props("project.version"))
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.0.0")
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"

--- a/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/test
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/test
@@ -1,0 +1,5 @@
+> sandbox debug
+
+> checkDockerContainers
+
+> sandbox stop


### PR DESCRIPTION
This PR is added a new setting key `debugPort` in order to debug a bundle.

Default debug port 5005. This is the default remote debug port of IntelliJ.

The debug port is exposed to the ConductR and Docker containers. The docker public port gets mapped based on the convention which is used for `SanboxKeys.ports` and `BundleKeys.endpoints` as well.

Additionally the debug port is added as an argument `-jvm-debug $debugPort` to the `BundleKeys.startCommand` in order to enable debugging of a bundle. This change made it necessary to depend on `UniversalPlugin`. Otherwise the additional argument will not be added to the `start-command` in the `bundle.conf`.

The PR has been unit tested with a new [sbt-test](https://github.com/markusjura/sbt-conductr-sandbox/tree/b229e111c4326a2eb7f52344c79be98ee792037d/src/sbt-test/sbt-conductr-sandbox/ports) and acceptance tested with an external Play application to ensure that remote debugging of the application inside a sandbox cluster in IntelliJ works.

I've also enhanced the README. It explains now in more detail how the different ports are mapped to the ConductR and Docker containers.

> Note: This plugin can only be used in combination with `sbt-bundle` due to the fact that we add an addtional argument to `BundleKeys.startCommand`. Therefor when using this plugin all mandatory `BundleKeys` need to be specified (`nrOfCpus`, `memory`, `diskSpace`).

@huntc: Please review and merge. Also wouldn't it make sense to depend on `sbt-conductr` so that the user doesn't need to specify both plugins in the `build.sbt`. Currently he need to do this:

```
lazy val root = (project in file(".")).enablePlugins(ConductRPlugin, ConductRSandbox)
```

I feel that if the user want to use `sbt-conductr-sandbox` he also want to use `sbt-conductr`. So better would be this:

```
lazy val root = (project in file(".")).enablePlugins(ConductRSandbox)
```

WDYT?
