### PR TITLE
Configure travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,27 @@
 jdk: openjdk7
 language: scala
+
+env:
+  global:
+    - "HOST_IP=$(/sbin/ifconfig venet0:0 | grep 'inet addr' | awk -F: '{print $2}' | awk '{print $1}')"
+    - DOCKER_HOST=tcp://$HOST_IP:2375
+    - DOCKER_PORT_RANGE=2400:2500
+    - SLIRP_PORTS=$(seq 2375 2500)
+
+before_install:
+  - sudo sh -c "echo deb https://get.docker.com/ubuntu docker main > /etc/apt/sources.list.d/docker.list"
+  - sudo sh -c "apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9"
+  - echo exit 101 | sudo tee /usr/sbin/policy-rc.d
+  - sudo chmod +x /usr/sbin/policy-rc.d
+
+install:
+  - sudo apt-get -qqy update
+  - sudo apt-get -qqy install lxc-docker slirp
+  - sudo sudo usermod -aG docker "$USER"
+  - git clone git://github.com/cptactionhank/sekexe
+
+before_script:
+  - "sekexe/run 'mount -t tmpfs -o size=8g tmpfs /var/lib/docker && docker -d -H tcp://0.0.0.0:2375' &"
+  - "while ! docker info &> /dev/null ; do sleep 1; done"
+
 script: sbt scripted


### PR DESCRIPTION
Travis has not installed docker out-of-the-box. Our tests need docker to start the sandbox cluster. This PR installs docker in travis before executing the tests.

Travis currently still fails due to the fact that the docker image `conductr/conductr-dev` isn't published yet. However, now the travis build recognizes the docker commands inside of the test.
