### PR TITLE
Fixed up inconsistencies with org

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import bintray.Keys._
 
 sbtPlugin := true
 
-organization := "com.typesafe.sbt"
+organization := "com.typesafe.conductr"
 name := "sbt-conductr-sandbox"
 
 scalaVersion := "2.10.4"

--- a/src/main/scala/com/typesafe/conductr/sandbox/sbt/ConductRSandbox.scala
+++ b/src/main/scala/com/typesafe/conductr/sandbox/sbt/ConductRSandbox.scala
@@ -1,4 +1,4 @@
-package com.typesafe.sbt.conductrsandbox
+package com.typesafe.conductr.sandbox.sbt
 
 import com.typesafe.sbt.bundle.Import.BundleKeys
 import com.typesafe.conductr.sbt.ConductRKeys

--- a/src/sbt-test/sbt-conductr-sandbox/basic/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/basic/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-conductr-sandbox" % sys.props("project.version"))
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"

--- a/src/sbt-test/sbt-conductr-sandbox/ports-basic/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-basic/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-conductr-sandbox" % sys.props("project.version"))
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % sys.props("project.version"))
 addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.0.0")
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"

--- a/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-conductr-sandbox" % sys.props("project.version"))
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % sys.props("project.version"))
 addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.0.0")
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"


### PR DESCRIPTION
Tests will fail as we can't pull down the bintray based images yet. Error reported:

```
[info] [error] Unable to find image 'typesafe-docker-internal-docker.bintray.io/conductr/conductr-dev:latest' locally
```
