### PR TITLE
Programmatically stop the sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,7 @@ ports             | Global  | A `Seq[Int]` of ports to be made public by each of
 debugPort         | Project | Debug port to be made public to the ConductR containers if the sandbox gets started in [debug mode](#Commands). The debug ports of each sbt project setting will be used. If `sbt-bundle` is enabled the JVM argument `-jvm-debug $debugPort` is  additionally added to the `startCommand` of `sbt-bundle`. Default is 5005.
 logLevel          | Global  | The log level of ConductR which can be one of "debug", "warning" or "info". By default this is set to "info". You can observe ConductR's logging via the `docker logs` command. For example `docker logs -f cond-0` will follow the logs of the first ConductR container.
 nrOfContainers    | Global  | Sets the number of ConductR containers to run in the background. By default 1 is run. Note that by default you may only have more than one if the image being used is *not* conductr/conductr-dev (the default, single node version of ConductR for general development).
-runConductRs      | Global  | Starts the sandbox environment.
-stopConductRs     | Global  | Stops the sandbox environment.
+runConductRs      | Global  | Starts the sandbox environment as a task - useful for setting up test environments within sbt. Note that a `ConductRSandbox.stopConductRs(logger)` function call can be made to close down the sandbox environment programmatically. `logger` is of sbt's type `ProcessLogger`. Therefore a `streams.value.log` can be provided.
 
 ## Commands
 


### PR DESCRIPTION
The ability to stop a cluster was previously provided as a task. However a task is inappropriate given that it has differing semantics to a function call and can thus be evaluated unexpectedly. A function to stop the sandbox is now provided for programmatic scenarios.
