### PR TITLE
Adds imageVersion, tests now use single node

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ sbt-conductr-sandbox aims to support the running of a Docker-based ConductR clus
 
 ## Usage
 
+The single node version of the ConductR Developer Sandbox is available gratis with registration at Typesafe.com. Please visit the [ConductR Developer](http://www.typesafe.com/product/conductr/developer) page on Typesafe.com for the current image version and licensing information. Use of the ConductR in multi-node mode or for production purposes requires the purchase of Typesafe ConductR. You <strong>must</strong> specify the current imageVersion which you can obtain from the [ConductR Developer](http://www.typesafe.com/product/conductr/developer) page.
+
 If you have not done so already, then please [install Docker](https://www.docker.com/).
 
 Declare the plugin (typically in a `plugins.sbt`):
@@ -145,6 +147,7 @@ Name              | Scope   | Description
 ------------------|---------|------------
 envs              | Global  | A `Map[String, String]` of environment variables to be set for each ConductR container.
 image             | Global  | The Docker image to use. By default `typesafe-docker-internal-docker.bintray.io/conductr/conductr-dev` is used i.e. the single node version of ConductR. For the full version please [download it via our website](http://www.typesafe.com/products/conductr) and then use just `typesafe-docker-internal-docker.bintray.io/conductr/conductr`.
+imageVersion      | Global  | The version of the Docker image to use. Must be set. Please visit the [ConductR Developer](http://www.typesafe.com/product/conductr/developer) page on Typesafe.com for the current version and additional information.
 ports             | Global  | A `Seq[Int]` of ports to be made public by each of the ConductR containers. This will be complemented to the `endpoints` setting's service ports declared for `sbt-bundle`.
 debugPort         | Project | Debug port to be made public to the ConductR containers if the sandbox gets started in [debug mode](#Commands). The debug ports of each sbt project setting will be used. If `sbt-bundle` is enabled the JVM argument `-jvm-debug $debugPort` is  additionally added to the `startCommand` of `sbt-bundle`. Default is 5005.
 logLevel          | Global  | The log level of ConductR which can be one of "debug", "warning" or "info". By default this is set to "info". You can observe ConductR's logging via the `docker logs` command. For example `docker logs -f cond-0` will follow the logs of the first ConductR container.

--- a/src/sbt-test/sbt-conductr-sandbox/basic/test
+++ b/src/sbt-test/sbt-conductr-sandbox/basic/test
@@ -1,3 +1,7 @@
+-> sandbox run
+
+> 'set SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "0.1.0")'
+
 > sandbox run
 
 > checkConductRIsRunning

--- a/src/sbt-test/sbt-conductr-sandbox/ports-basic/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-basic/build.sbt
@@ -16,6 +16,7 @@ BundleKeys.endpoints := Map("other" -> Endpoint("http", services = Set(URI("http
 // ConductR sandbox keys
 SandboxKeys.ports in Global := Set(1111, 2222)
 SandboxKeys.debugPort := 5432
+SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "0.1.0")
 
 /**
  * Check ports after 'sandbox run' command

--- a/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/build.sbt
@@ -6,7 +6,7 @@ version := "0.1.0-SNAPSHOT"
 
 // ConductR global keys
 SandboxKeys.ports in Global := Set(1111, 2222)
-SandboxKeys.image in Global := "typesafe-docker-internal-docker.bintray.io/conductr/conductr-dev"
+SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "0.1.0")
 
 lazy val common = (project in file("modules/common"))
   .enablePlugins(ConductRSandbox)

--- a/src/sbt-test/sbt-conductr-sandbox/with-features/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/with-features/build.sbt
@@ -14,6 +14,8 @@ BundleKeys.nrOfCpus := 1.0
 BundleKeys.memory := 64.MiB
 BundleKeys.diskSpace := 10.MB
 
+SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "0.1.0")
+
 /**
  * Check ports after 'sandbox run' command
  */


### PR DESCRIPTION
Depends on https://github.com/typesafehub/Typesafe.com/pull/1038 for developer page being available.
Sets version in each test to enable basic to test for lack of value.
with-features fails for me similar as travis
