### PR TITLE
Fix image override

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ lazy val root = (project in file(".")).enablePlugins(ConductRPlugin, ConductRSan
 
 BundleKeys.endpoints := Map("sample-app" -> Endpoint("http", services = Set(uri("http://:9000"))))
 SandboxKeys.image in Global := "conductr/conductr"
+SandboxKeys.imageVersion in Global := "latest"
 SandboxKeys.nrOfContainers in Global := 3
 SandboxKeys.ports in Global := Set(1111)
 SandboxKeys.debugPort := 5095

--- a/src/main/scala/com/typesafe/conductr/sandbox/sbt/ConductRSandbox.scala
+++ b/src/main/scala/com/typesafe/conductr/sandbox/sbt/ConductRSandbox.scala
@@ -113,14 +113,15 @@ object ConductRSandbox extends AutoPlugin {
 
   // FIXME: The filter must be passed in presently: https://github.com/sbt/sbt/issues/1095
   private def runConductRsTask(filter: ScopeFilter): Def.Initialize[Task[Unit]] = Def.task {
-    val imageVer = (imageVersion in Global).?.map(_.getOrElse {
+    val conductrImage = (image in Global).value
+    val conductrImageVersion = (imageVersion in Global).?.map(_.getOrElse {
       fail("imageVersion. imageVersion must be set. Please visit https://www.typesafe.com/product/conductr/developer for current version information.")
       ""
     }).value
 
-    if ((image in Global).value == ConductRDevImage && s"docker images -q $ConductRDevImage".!!.isEmpty) {
+    if (conductrImage == ConductRDevImage && s"docker images -q $ConductRDevImage".!!.isEmpty) {
       streams.value.log.info("Pulling down the development version of ConductR * * * SINGLE NODED AND NOT FOR PRODUCTION USAGE * * *")
-      s"docker pull $ConductRDevImage:$imageVer".!(streams.value.log)
+      s"docker pull $ConductRDevImage:$conductrImageVersion".!(streams.value.log)
     }
 
     val features = state.value.get(WithFeaturesAttrKey).toSet.flatten
@@ -156,7 +157,7 @@ object ConductRSandbox extends AutoPlugin {
           container,
           cond0Ip,
           (envs in Global).value,
-          s"$ConductRDevImage:$imageVer",
+          s"$conductrImage:$conductrImageVersion",
           (logLevel in Global).value,
           allPorts,
           features.map(_.name)


### PR DESCRIPTION
The value of the overriden `SandboxKeys.image` was not used to run ConductR. This PR fixes this.
