### PR TITLE
Auto enable sbt-conductr-sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,7 @@ Declare the plugin (typically in a `plugins.sbt`):
 addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.0.5")
 ```
 
-Then enable the `ConductRSandbox` plugin for your module. For example:
-
-```scala
-lazy val root = (project in file(".")).enablePlugins(ConductRSandbox)
-```
+Nothing more is required to enable the plugin.
 
 ### Starting ConductR sandbox
 
@@ -112,7 +108,7 @@ The following ports are exposed to the ConductR and Docker containers:
 Your application defines these settings in the `build.sbt`:
 
 ```
-lazy val root = (project in file(".")).enablePlugins(ConductRPlugin, ConductRSandbox)
+lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging)
 
 BundleKeys.endpoints := Map("sample-app" -> Endpoint("http", services = Set(uri("http://:9000"))))
 SandboxKeys.image in Global := "conductr/conductr"

--- a/build.sbt
+++ b/build.sbt
@@ -23,8 +23,7 @@ ScalariformKeys.preferences := ScalariformKeys.preferences.value
   .setPreference(PreserveDanglingCloseParenthesis, true)
 
 resolvers += Resolver.bintrayRepo("typesafe", "maven-releases")
-addSbtPlugin("com.typesafe.sbt" % "sbt-bundle"        % "1.0.0")
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.0.0")
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.0.1")
 
 releaseSettings
 ReleaseKeys.versionBump := sbtrelease.Version.Bump.Minor

--- a/sbt-conductr-sandbox-tester/build.sbt
+++ b/sbt-conductr-sandbox-tester/build.sbt
@@ -1,6 +1,6 @@
 import ByteConversions._
 
-lazy val root = (project in file(".")).enablePlugins(ConductRPlugin, ConductRSandbox)
+lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging)
 
 name := "simple-test"
 

--- a/src/main/scala/com/typesafe/conductr/sandbox/sbt/ConductRSandbox.scala
+++ b/src/main/scala/com/typesafe/conductr/sandbox/sbt/ConductRSandbox.scala
@@ -60,6 +60,8 @@ object ConductRSandbox extends AutoPlugin {
 
   val autoImport = Import
 
+  override def trigger = allRequirements
+
   override def globalSettings: Seq[Setting[_]] =
     super.globalSettings ++ Seq(
       envs := Map.empty,

--- a/src/sbt-test/sbt-conductr-sandbox/basic/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/basic/build.sbt
@@ -1,7 +1,5 @@
 import org.scalatest.Matchers._
 
-lazy val root = (project in file(".")).enablePlugins(ConductRSandbox)
-
 name := "simple-test"
 
 version := "0.1.0-SNAPSHOT"

--- a/src/sbt-test/sbt-conductr-sandbox/ports-basic/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-basic/build.sbt
@@ -1,7 +1,7 @@
 import org.scalatest.Matchers._
 import ByteConversions._
 
-lazy val root = (project in file(".")).enablePlugins(ConductRPlugin, ConductRSandbox)
+lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging)
 
 name := "ports-basic"
 

--- a/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/build.sbt
@@ -9,13 +9,12 @@ SandboxKeys.ports in Global := Set(1111, 2222)
 SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.9")
 
 lazy val common = (project in file("modules/common"))
-  .enablePlugins(ConductRSandbox)
   .settings(
     SandboxKeys.debugPort := 8888
   )
 
 lazy val frontend = (project in file("modules/frontend"))
-  .enablePlugins(ConductRPlugin, ConductRSandbox)
+  .enablePlugins(JavaAppPackaging)
   .dependsOn(common)
   .settings(
     BundleKeys.nrOfCpus := 1.0,
@@ -27,7 +26,7 @@ lazy val frontend = (project in file("modules/frontend"))
   )
 
 lazy val backend = (project in file("modules/backend"))
-  .enablePlugins(ConductRPlugin, ConductRSandbox)
+  .enablePlugins(JavaAppPackaging)
   .dependsOn(common)
   .settings(
     BundleKeys.nrOfCpus := 1.0,

--- a/src/sbt-test/sbt-conductr-sandbox/with-features/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/with-features/build.sbt
@@ -1,7 +1,7 @@
 import org.scalatest.Matchers._
 import ByteConversions._
 
-lazy val root = (project in file(".")).enablePlugins(ConductRSandbox)
+lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging)
 
 name := "with-features"
 


### PR DESCRIPTION
As the plugin's capabilities are global to a project, enable it automatically.

Also uses the latest sbt-conductr.
