### PR TITLE
Include Kibana to logging feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ sandbox stop
 
 ConductR provides additional features which can be optionally enabled:
 
-Name          | CondutR port | Docker port | Description
---------------|--------------|-------------|------------
-visualization | 9999         | 9909        | Provides a web interface to visualize the ConductR cluster together with deployed and running bundles.  After enabling the feature, access it at http://{docker-host-ip}:9909.
-logging       | 9200         | 9200        | Consolidates the logging output of ConductR itself and the bundles that it executes. To view the consolidated log messsages enable [sbt-conductr](https://github.com/sbt/sbt-conductr) and then `conduct logs conductr-elasticsearch`.
+Name          | CondutR ports | Docker ports | Description
+--------------|---------------|-------------|------------
+visualization | 9999          | 9909        | Provides a web interface to visualize the ConductR cluster together with deployed and running bundles.  After enabling the feature, access it at http://{docker-host-ip}:9909.
+logging       | 9200, 5601    | 9200, 5601  | Consolidates the logging output of ConductR itself and the bundles that it executes. To view the consolidated log messsages access http://{docker-host-ip}:5601 or enable [sbt-conductr](https://github.com/sbt/sbt-conductr) and then `conduct logs {bundle-name}`.
 
 ## Docker Container Naming
 

--- a/sbt-conductr-sandbox-tester/build.sbt
+++ b/sbt-conductr-sandbox-tester/build.sbt
@@ -9,7 +9,7 @@ version := "0.1.0-SNAPSHOT"
 BundleKeys.nrOfCpus := 1.0
 BundleKeys.memory := 64.MiB
 BundleKeys.diskSpace := 10.MB
-BundleKeys.roles := Set("web-server")
+BundleKeys.roles := Set("web")
 BundleKeys.startCommand := Seq("-Xms1G")
 
 BundleKeys.configurationName := "frontend"

--- a/sbt-conductr-sandbox-tester/project/plugins.sbt
+++ b/sbt-conductr-sandbox-tester/project/plugins.sbt
@@ -2,4 +2,4 @@ lazy val root = Project("plugins", file(".")).dependsOn(plugin)
 
 lazy val plugin = file("../").getCanonicalFile.toURI
 
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.0.0")
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.1.0")

--- a/src/main/scala/com/typesafe/conductr/sandbox/sbt/ConductRSandbox.scala
+++ b/src/main/scala/com/typesafe/conductr/sandbox/sbt/ConductRSandbox.scala
@@ -186,7 +186,7 @@ object ConductRSandbox extends AutoPlugin {
 
     val features = state.value.get(WithFeaturesAttrKey).toSet.flatten
 
-    val featurePorts = features.map(_.port)
+    val featurePorts = features.flatMap(_.port)
 
     val bundlePorts = BundleKeys.endpoints.?.map(_.getOrElse(Map.empty)).all(filter).value.reduce(_ ++ _)
       .flatMap {
@@ -248,6 +248,7 @@ object ConductRSandbox extends AutoPlugin {
     // Expose always the feature related ports even if the are not specified with `--withFeatures`.
     // Therefor these ports are also exposed if only the `runConductRs` tasks is executed (e.g. in testing)
     val conductrPorts = Set(
+      5601, // conductr-kibana bundle
       9004, // ConductR internal akka remoting
       9005, // ConductR controlServer
       9006, // ConductR bundleStreamServer
@@ -358,12 +359,12 @@ object ConductRSandbox extends AutoPlugin {
   private case class DebugSubtask(features: Set[String]) extends ConductrSandboxSubtask
   private case object StopSubtask extends ConductrSandboxSubtask
 
-  private case class Feature(name: String, port: Int)
+  private case class Feature(name: String, port: Set[Int])
   private object Feature {
     def apply(name: String): Feature =
       name match {
-        case "visualization" => Feature(name, 9999)
-        case "logging"       => Feature(name, 9200)
+        case "visualization" => Feature(name, Set(9999))
+        case "logging"       => Feature(name, Set(5601, 9200))
       }
   }
 }

--- a/src/sbt-test/sbt-conductr-sandbox/conductr-roles/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/conductr-roles/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % sys.props("project.version"))
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.0.0")
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.1.0")
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"

--- a/src/sbt-test/sbt-conductr-sandbox/ports-basic/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-basic/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % sys.props("project.version"))
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.0.0")
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.1.0")
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"

--- a/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % sys.props("project.version"))
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.0.0")
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.1.0")
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"

--- a/src/sbt-test/sbt-conductr-sandbox/with-features/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/with-features/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % sys.props("project.version"))
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.0.0")
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.1.0")
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"


### PR DESCRIPTION
Include `conductr-kibana` to the logging feature so that `conductr-elasticsearch` and `conductr-kibana` are automatically started if the `logging` feature is enabled.

Corresponding `conductr` PR is https://github.com/typesafehub/conductr/pull/744.
