### PR TITLE
Enable ES for the sandbox based ConductR 1.0

### DIFF
--- a/src/main/scala/com/typesafe/conductr/sandbox/sbt/package.scala
+++ b/src/main/scala/com/typesafe/conductr/sandbox/sbt/package.scala
@@ -1,0 +1,13 @@
+package com.typesafe.conductr.sandbox
+
+package object sbt {
+
+  implicit class MapOps[A, B >: String](left: Map[A, B]) {
+
+    def merge(right: Map[A, B], separator: String = " "): Map[A, B] =
+      right.foldLeft(left) {
+        case (acc, (k, v)) =>
+          acc + (k -> s"${acc.get(k).map(_ + separator + v).getOrElse(v)}")
+      }
+  }
+}

--- a/src/sbt-test/sbt-conductr-sandbox/with-features/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/with-features/build.sbt
@@ -7,11 +7,13 @@ name := "with-features"
 
 version := "0.1.0-SNAPSHOT"
 
+val envValue = "-dSomeBundleKey=100"
+
 // ConductR bundle keys
 BundleKeys.nrOfCpus := 1.0
 BundleKeys.memory := 64.MiB
 BundleKeys.diskSpace := 10.MB
-
+SandboxKeys.envs in Global := Map("CONDUCTR_ARGS" -> envValue)
 SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.9")
 
 /**
@@ -31,6 +33,8 @@ checkPorts := {
 val checkEnvs = taskKey[Unit]("Check if environment variables for features are set.")
 checkEnvs := {
   val content = "docker inspect --format='{{.Config.Env}}' cond-0".!!
-  val expectedContent = "CONDUCTR_FEATURES=visualization,logging"
-  content should include(expectedContent)
+  val expectedConductrFeatures = "CONDUCTR_FEATURES=visualization,logging"
+  content should include(expectedConductrFeatures)
+  val expectedConductrArgs = s"CONDUCTR_ARGS=$envValue -Dcontrail.syslog.server.port=9200 -Dcontrail.syslog.server.elasticsearch.enabled=on"
+  content should include(expectedConductrArgs)
 }


### PR DESCRIPTION
Fixes https://github.com/typesafehub/conductr/issues/832 by:
- Refactoring `Feature` to `SandboxFeature` and adding the parameter `envs` to specify environment variables for a feature
- Merging the features envs with the `SandboxKeys.envs`. Example:
  - The logging feature is adding these environment variables:
    
    ```
    Map("CONDUCTR_ARGS" -> "-Dcontrail.syslog.server.port=9200 -Dcontrail.syslog.server.elasticsearch.enabled=on")
    ```
  - The user specifies these additional environment variables:
    
    ```
    SandboxKeys.envs in Global := Map("CONDUCTR_ARGS" -> "-Duser.env=100"
    ```
  - In this case both values of `CONDUCTR_ARGS` are merged and separated by a whitespace
    
    ```
    Map("CONDUCTR_ARGS" -> "-Duser.env=100 -Dcontrail.syslog.server.port=9200 -Dcontrail.syslog.server.elasticsearch.enabled=on"
    ```
