### PR TITLE
Set image version for reactive-platform project

### DIFF
--- a/sbt-conductr-sandbox-tester/build.sbt
+++ b/sbt-conductr-sandbox-tester/build.sbt
@@ -15,6 +15,6 @@ BundleKeys.startCommand := Seq("-Xms1G")
 BundleKeys.configurationName := "frontend"
 
 SandboxKeys.ports in Global := Set(9999)
-SandboxKeys.imageVersion in Global := "1.0.9"
+SandboxKeys.imageVersion in Global := "1.0.11"
 
 SandboxKeys.debugPort := 5432

--- a/src/sbt-test/sbt-conductr-sandbox/basic/test
+++ b/src/sbt-test/sbt-conductr-sandbox/basic/test
@@ -1,4 +1,4 @@
-> 'set SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.9")'
+> 'set SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.11")'
 
 > sandbox run
 

--- a/src/sbt-test/sbt-conductr-sandbox/conductr-roles/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/conductr-roles/build.sbt
@@ -17,7 +17,7 @@ BundleKeys.diskSpace := 10.MB
 BundleKeys.roles := Set("bundle-role-1", "bundle-role-2")
 
 // ConductR sandbox keys
-SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.9")
+SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.11")
 
 val checkConductrRolesByBundle = taskKey[Unit]("Check that the bundle roles are used if no SandboxKeys.conductrRoles is specified.")
 checkConductrRolesByBundle := {

--- a/src/sbt-test/sbt-conductr-sandbox/ports-basic/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-basic/build.sbt
@@ -16,7 +16,7 @@ BundleKeys.endpoints := Map("other" -> Endpoint("http", services = Set(URI("http
 // ConductR sandbox keys
 SandboxKeys.ports in Global := Set(1111, 2222)
 SandboxKeys.debugPort := 5432
-SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.9")
+SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.11")
 
 /**
  * Check ports after 'sandbox run' command

--- a/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/build.sbt
@@ -6,7 +6,7 @@ version := "0.1.0-SNAPSHOT"
 
 // ConductR global keys
 SandboxKeys.ports in Global := Set(1111, 2222)
-SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.9")
+SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.11")
 
 lazy val common = (project in file("modules/common"))
   .settings(

--- a/src/sbt-test/sbt-conductr-sandbox/with-features/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/with-features/build.sbt
@@ -12,7 +12,7 @@ BundleKeys.nrOfCpus := 1.0
 BundleKeys.memory := 64.MiB
 BundleKeys.diskSpace := 10.MB
 
-SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.9")
+SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.11")
 
 /**
  * Check ports after 'sandbox run' command

--- a/src/sbt-test/sbt-conductr-sandbox/with-rp-license/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/with-rp-license/build.sbt
@@ -1,0 +1,13 @@
+import org.scalatest.Matchers._
+import ByteConversions._
+
+lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging)
+
+name := "with-rp-license"
+
+version := "0.1.0-SNAPSHOT"
+
+// ConductR bundle keys
+BundleKeys.nrOfCpus := 1.0
+BundleKeys.memory := 64.MiB
+BundleKeys.diskSpace := 10.MB

--- a/src/sbt-test/sbt-conductr-sandbox/with-rp-license/project/build.properties
+++ b/src/sbt-test/sbt-conductr-sandbox/with-rp-license/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.8

--- a/src/sbt-test/sbt-conductr-sandbox/with-rp-license/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/with-rp-license/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % sys.props("project.version"))
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.1.0")
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"

--- a/src/sbt-test/sbt-conductr-sandbox/with-rp-license/test
+++ b/src/sbt-test/sbt-conductr-sandbox/with-rp-license/test
@@ -1,0 +1,3 @@
+> sandbox run
+
+> sandbox stop


### PR DESCRIPTION
Fixes issue https://github.com/sbt/sbt-conductr/issues/112.

If the project has an active reactive platform license and the `imageVersion` is not set by the user, then the `imageVersion` is set to the latest ConductR version. This should make the first user experience slicker.
