### PR TITLE
Improved the scope of debug

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ ScalariformKeys.preferences := ScalariformKeys.preferences.value
   .setPreference(PreserveDanglingCloseParenthesis, true)
 
 resolvers += Resolver.bintrayRepo("typesafe", "maven-releases")
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.1.0")
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.1.1")
 
 releaseSettings
 ReleaseKeys.versionBump := sbtrelease.Version.Bump.Minor

--- a/sbt-conductr-sandbox-tester/build.sbt
+++ b/sbt-conductr-sandbox-tester/build.sbt
@@ -9,7 +9,7 @@ version := "0.1.0-SNAPSHOT"
 BundleKeys.nrOfCpus := 1.0
 BundleKeys.memory := 64.MiB
 BundleKeys.diskSpace := 10.MB
-BundleKeys.roles := Set("web")
+BundleKeys.roles := Set("bundle-role-1", "bundle-role-2")
 BundleKeys.startCommand := Seq("-Xms1G")
 
 BundleKeys.configurationName := "frontend"

--- a/src/sbt-test/sbt-conductr-sandbox/ports-basic/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-basic/build.sbt
@@ -43,7 +43,7 @@ checkPortsWithRun := {
  */
 val checkRunStartCommand = taskKey[Unit]("Check the start-command in bundle.conf. jvm-debug should not be part of it.")
 checkRunStartCommand := {
-  val contents = IO.read((target in Bundle).value / "tmp" / "bundle.conf")
+  val contents = IO.read((target in Bundle).value / "bundle"/ "tmp" / "bundle.conf")
   val expectedContents = """start-command    = ["ports-basic/bin/ports-basic", "-J-Xms67108864", "-J-Xmx67108864"]""".stripMargin
   contents should include(expectedContents)
 }
@@ -74,7 +74,7 @@ checkPortsWithDebug := {
  */
 val checkDebugStartCommand = taskKey[Unit]("Check the start-command in bundle.conf. jvm-debug should be part of it.")
 checkDebugStartCommand := {
-  val contents = IO.read((target in Bundle).value / "tmp" / "bundle.conf")
-  val expectedContents = """start-command    = ["ports-basic/bin/ports-basic", "-J-Xms67108864", "-J-Xmx67108864", "-jvm-debug 5432"]""".stripMargin
+  val contents = IO.read((target in Bundle).value / "bundle" / "tmp" / "bundle.conf")
+  val expectedContents = """start-command    = ["ports-basic/bin/ports-basic", "-J-Xms67108864", "-J-Xmx67108864", "-jvm-debug", "5432"]""".stripMargin
   contents should include(expectedContents)
 }


### PR DESCRIPTION
Debug settings are now made on a per project basis. They appeared to be made just for the current project before.

These changes also tolerate the startCommand being a task, which it needs to be given the dependency on sbt's debugOptions task.
