### PR TITLE
Ports could be dropped given duplicate endpoint labels

### DIFF
--- a/src/main/scala/com/typesafe/conductr/sandbox/sbt/ConductRSandbox.scala
+++ b/src/main/scala/com/typesafe/conductr/sandbox/sbt/ConductRSandbox.scala
@@ -244,15 +244,17 @@ object ConductRSandbox extends AutoPlugin {
 
     val featurePorts = features.flatMap(_.port)
 
-    val bundlePorts = (BundleKeys.endpoints in Bundle).?.map(_.getOrElse(Map.empty)).all(filter).value.reduce(_ ++ _)
-      .flatMap {
-        case (_, endpoint) =>
-          endpoint.services.map { uri =>
-            if (uri.getHost != null) uri.getPort else uri.getAuthority.drop(1).toInt
-          }.collect {
-            case port if port >= 0 => port
-          }
-      }.toSet
+    val bundlePorts = (BundleKeys.endpoints in Bundle).?.map(_.getOrElse(Map.empty)).all(filter).value
+      .flatten
+      .map(_._2)
+      .toSet
+      .flatMap { endpoint: Endpoint =>
+        endpoint.services.map { uri =>
+          if (uri.getHost != null) uri.getPort else uri.getAuthority.drop(1).toInt
+        }.collect {
+          case port if port >= 0 => port
+        }
+      }
 
     val debugPorts = state.value.get(WithDebugAttrKey).fold(Set.empty[Int])(_ => debugPort.?.all(filter).value.flatten.toSet)
 

--- a/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/build.sbt
@@ -33,7 +33,10 @@ lazy val backend = (project in file("modules/backend"))
     BundleKeys.memory := 128.MiB,
     BundleKeys.diskSpace := 50.MiB,
     BundleKeys.roles := Set("backend"),
-    BundleKeys.endpoints := Map("backend" -> Endpoint("http", services = Set(URI("http://:2551")))),
+    BundleKeys.endpoints := Map(
+      "frontend" -> Endpoint("http", services = Set(URI("http://:9001"))),
+      "backend" -> Endpoint("http", services = Set(URI("http://:2551")))
+    ),
     SandboxKeys.debugPort := 2999
   )
 
@@ -43,6 +46,7 @@ checkDockerContainers := {
   // cond-0
   val contentCond0 = s"docker port cond-0".!!
   val expectedLinesCond0 = Set(
+    """9001/tcp -> 0.0.0.0:9001""",
     """9004/tcp -> 0.0.0.0:9004""",
     """9005/tcp -> 0.0.0.0:9005""",
     """9006/tcp -> 0.0.0.0:9006""",


### PR DESCRIPTION
If an endpoint's label was the same across multiple projects, yet different in value, then one of them could be lost.
