### PR TITLE
Narrowed the setting scope to include thisProjectRef

### DIFF
--- a/src/sbt-test/sbt-conductr-sandbox/ports-basic/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-basic/build.sbt
@@ -75,6 +75,6 @@ checkPortsWithDebug := {
 val checkDebugStartCommand = taskKey[Unit]("Check the start-command in bundle.conf. jvm-debug should be part of it.")
 checkDebugStartCommand := {
   val contents = IO.read((target in Bundle).value / "bundle" / "tmp" / "bundle.conf")
-  val expectedContents = """start-command    = ["ports-basic/bin/ports-basic", "-J-Xms67108864", "-J-Xmx67108864", "-jvm-debug", "5432"]""".stripMargin
+  val expectedContents = """start-command    = ["ports-basic/bin/ports-basic", "-jvm-debug", "5432", "-J-Xms67108864", "-J-Xmx67108864"]""".stripMargin
   contents should include(expectedContents)
 }


### PR DESCRIPTION
`thisProjectRef` was necessary to narrow the setting test to the project associated with it in order to prevent other scopes stomping over the value.

`scripted` tests pass.

The setting logic has also been simplified by using a conditional task assignment.

The Visualizer was tested to work in the ConductR project i.e. bundle:dist, conduct load, conduct run...

The Visualizer also gets bundled correctly for the ConductR packaging i.e. conductr/docker:publishLocal and then unpack the resulting samples/visualizer package of the docker stage folder. In addition I ran the sandbox against the new image and used the --with-features visualizer.

Fixes https://github.com/typesafehub/conductr/issues/883

May also fix #37 
