### PR TITLE
Rename --withFeatures to --with-features

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ If the `sbt-conductr` plugin is enabled for your project then the `conduct info`
 
 #### Starting with ConductR features
 
-To enable optional ConductR features for your sandbox specify the `--withFeatures` option during startup, e.g.:
+To enable optional ConductR features for your sandbox specify the `--with-features` option during startup, e.g.:
     
 ```scala
-[my-app] sandbox run --withFeatures visualization logging
+[my-app] sandbox run --with-features visualization logging
 [info] Running ConductR...
 [info] Running container cond-0 exposing 192.168.59.103:9000 192.168.59.103:9909...
 ```

--- a/src/main/scala/com/typesafe/conductr/sandbox/sbt/ConductRSandbox.scala
+++ b/src/main/scala/com/typesafe/conductr/sandbox/sbt/ConductRSandbox.scala
@@ -304,7 +304,7 @@ object ConductRSandbox extends AutoPlugin {
     val conductrRolesEnv = toMap("CONDUCTR_ROLES", conductrRoles)(_.mkString(","))
     val envsArgs = (envsValue ++ logLevelEnv ++ syslogEnv ++ conductrFeatureArgs ++ conductrRolesEnv).flatMap { case (k, v) => Seq("-e", s"$k=$v") }.toSeq
 
-    // Expose always the feature related ports even if the are not specified with `--withFeatures`.
+    // Expose always the feature related ports even if the are not specified with `--with-features`.
     // Therefor these ports are also exposed if only the `runConductRs` tasks is executed (e.g. in testing)
     val conductrPorts = Set(
       5601, // conductr-kibana bundle
@@ -406,7 +406,7 @@ object ConductRSandbox extends AutoPlugin {
       (token("debug") ~> OptSpace ~> withFeatures.?) map { case features => DebugSubtask(features.toSet.flatten) }
     def stopSubtask: Parser[StopSubtask.type] = token("stop") map { case _ => StopSubtask }
 
-    def withFeatures: Parser[Set[String]] = "--withFeatures" ~> Space ~> features
+    def withFeatures: Parser[Set[String]] = "--with-features" ~> Space ~> features
     def features: Parser[Set[String]] =
       repeatDep((remainingFeatures: Seq[String]) =>
         StringBasic.examples(FixedSetExamples(ConductrFeatures diff remainingFeatures.toSet), 1, removeInvalidExamples = true), Space).map(_.toSet)

--- a/src/sbt-test/sbt-conductr-sandbox/with-features/test
+++ b/src/sbt-test/sbt-conductr-sandbox/with-features/test
@@ -1,4 +1,4 @@
-> sandbox run --withFeatures visualization logging
+> sandbox run --with-features visualization logging
 
 > checkPorts
 


### PR DESCRIPTION
Fixes issue https://github.com/typesafehub/sbt-conductr-sandbox/issues/46.

Name is also now aligned with `conductr-cli`.
