### PR TITLE
Use sbt-conductr to resolve conductr ip

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,7 @@ ScalariformKeys.preferences := ScalariformKeys.preferences.value
   .setPreference(PreserveDanglingCloseParenthesis, true)
 
 resolvers += Resolver.bintrayRepo("typesafe", "maven-releases")
+
 addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.1.2")
 
 releaseSettings


### PR DESCRIPTION
The conductr host ip can be now resolved by using the `sbt-conductr` key `ConductRKeys.conductrControlServerUrl`. Now this key contains either the docker host ip or the ip resolved by the terminal command `hostname`. This change have been made in the PR https://github.com/sbt/sbt-conductr/pull/117.

With this change a bug is fixed as well. So far we resolved the ip address by either using the docker host ip or the local host ip. This resolved ip address was then displayed as an output of the command `sandbox run`. The `controlServer` ip address has been ignored. This resulted into a problem if the user has set the `controlServer` manually. In this case we still outputted the docker / hostname ip address instead of the address of the control server. Now we always display the ip address of the control server.

This PR can't be merged yet because it uses a SNAPSHOT version of `sbt-condutr`. Ones a new version of `sbt-conductr` with the PR https://github.com/sbt/sbt-conductr/pull/117 has been released we can upgrade the version here accordingly.
