### PR TITLE
Require sbt-conductr

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To get started quickly, sbt-conductr-sandbox is using a pre-packaged Docker imag
 Verify the installation by entering the following command into the terminal:
 
 ```bash
-$ docker-machine
+docker-machine
 Usage: docker-machine [OPTIONS] COMMAND [arg...]
 ...
 ```
@@ -45,7 +45,7 @@ Nothing more is required to enable the plugin.
 
 ### Starting ConductR sandbox
 
-To run the sandbox environment use the following command in the sbt session:
+To run the sandbox environment run the following command inside the sbt session:
 
 ```scala
 sandbox run
@@ -55,7 +55,7 @@ sandbox run
 
 Given the above you will then have a ConductR process running in the background (there will be an initial download cost for Docker to download the image from the public Docker registry).
 
-If the `sbt-conductr` plugin is enabled for your project then the `conduct info` and other `conduct` commands will automatically communicate with the Docker cluster managed by the sandbox.
+This plugin automatically enables `sbt-conductr` for your project so you can use the `conduct info` and other `conduct` commands. These commands will automatically communicate with the Docker cluster managed by the sandbox.
 
 #### Starting with ConductR features
 
@@ -83,7 +83,7 @@ It is possible to debug your application inside of the ConductR sandbox:
     ```scala
     SandboxKeys.debugPort := 5432
     ```    
-4. Load and run your bundle to the sandbox, e.g. by using [sbt-conductr](https://github.com/sbt/sbt-conductr):
+4. Load and run your bundle to the sandbox:
 
     ```scala
     conduct load <HIT THE TAB KEY AND THEN RETURN>
@@ -114,7 +114,7 @@ ConductR provides additional features which can be optionally enabled:
 Name          | CondutR ports | Docker ports | Description
 --------------|---------------|-------------|------------
 visualization | 9999          | 9909        | Provides a web interface to visualize the ConductR cluster together with deployed and running bundles.  After enabling the feature, access it at http://{docker-host-ip}:9909.
-logging       | 9200, 5601    | 9200, 5601  | Consolidates the logging output of ConductR itself and the bundles that it executes. To view the consolidated log messsages access http://{docker-host-ip}:5601 or enable [sbt-conductr](https://github.com/sbt/sbt-conductr) and then `conduct logs {bundle-name}`.
+logging       | 9200, 5601    | 9200, 5601  | Consolidates the logging output of ConductR itself and the bundles that it executes. To view the consolidated log messsages run `conduct logs {bundle-name} or access the Kibana UI at http://{docker-host-ip}:5601.
 
 ## Docker Container Naming
 

--- a/sbt-conductr-sandbox-tester/project/plugins.sbt
+++ b/sbt-conductr-sandbox-tester/project/plugins.sbt
@@ -1,5 +1,3 @@
 lazy val root = Project("plugins", file(".")).dependsOn(plugin)
 
 lazy val plugin = file("../").getCanonicalFile.toURI
-
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.1.0")

--- a/src/main/scala/com/typesafe/conductr/sandbox/sbt/ConductRSandbox.scala
+++ b/src/main/scala/com/typesafe/conductr/sandbox/sbt/ConductRSandbox.scala
@@ -1,5 +1,6 @@
 package com.typesafe.conductr.sandbox.sbt
 
+import com.typesafe.conductr.sbt.ConductRPlugin
 import sbt._
 import sbt.Keys._
 import complete.DefaultParsers._
@@ -76,6 +77,8 @@ object ConductRSandbox extends AutoPlugin {
   val autoImport = Import
 
   override def trigger = allRequirements
+
+  override def requires = ConductRPlugin
 
   override def globalSettings: Seq[Setting[_]] =
     super.globalSettings ++ Seq(

--- a/src/sbt-test/sbt-conductr-sandbox/conductr-roles/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/conductr-roles/project/plugins.sbt
@@ -1,3 +1,2 @@
 addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % sys.props("project.version"))
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.1.0")
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"

--- a/src/sbt-test/sbt-conductr-sandbox/ports-basic/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-basic/project/plugins.sbt
@@ -1,3 +1,2 @@
 addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % sys.props("project.version"))
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.1.0")
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"

--- a/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/project/plugins.sbt
@@ -1,3 +1,2 @@
 addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % sys.props("project.version"))
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.1.0")
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"

--- a/src/sbt-test/sbt-conductr-sandbox/with-features/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/with-features/project/plugins.sbt
@@ -1,3 +1,2 @@
 addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % sys.props("project.version"))
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.1.0")
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"

--- a/src/sbt-test/sbt-conductr-sandbox/with-rp-license/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/with-rp-license/project/plugins.sbt
@@ -1,3 +1,2 @@
 addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % sys.props("project.version"))
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.1.0")
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"


### PR DESCRIPTION
The `sbt-conductr` command is automatically enabled when pulling the dependency in because `sbt-conductr` is global. For documentation purposes `sbt-conductr-sandbox` requires now `sbt-conductr` to make this more obvious.

Also `sbt-conductr` has been removed as the dependency in the test `plugins.sbt` files (not necessary anymore).
