### PR TITLE
Force to run only one container if dev image is used

### DIFF
--- a/src/main/scala/com/typesafe/conductr/sandbox/sbt/ConductRSandbox.scala
+++ b/src/main/scala/com/typesafe/conductr/sandbox/sbt/ConductRSandbox.scala
@@ -274,7 +274,13 @@ object ConductRSandbox extends AutoPlugin {
       s"docker pull $ConductRDevImage:$conductrImageVersion".!(streams.value.log)
     }
 
-    val nrOfContainers = state.value.get(NrOfContainersAttrKey).getOrElse(DefaultNrOfContainers)
+    val nrOfContainers = state.value.get(NrOfContainersAttrKey) match {
+      case None => DefaultNrOfContainers
+      case Some(nrOfContainers) if conductrImage == ConductRDevImage && nrOfContainers > DefaultNrOfContainers =>
+        streams.value.log.warn("Only a single node can be used in the development version of ConductR. Setting --nr-of-containers to 1.")
+        DefaultNrOfContainers
+      case Some(nrOfContainers) => nrOfContainers
+    }
 
     val features = state.value.get(WithFeaturesAttrKey).toSet.flatten
 

--- a/src/sbt-test/sbt-conductr-sandbox/scaling/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/scaling/build.sbt
@@ -5,6 +5,18 @@ name := "scaling"
 
 version := "0.1.0-SNAPSHOT"
 
+// FIXME: Once the docker image with the full ConductR version is available this test should
+//        execute the following steps in the test file:
+//        > sandbox run
+//        > checkContainers1
+//        > sandbox run --nr-of-containers 3
+//        > checkContainers3
+//        > sandbox run --nr-of-containers 2
+//        > checkContainers2
+//        > sandbox stop
+//        > checkContainers0
+
+
 // ConductR bundle keys
 BundleKeys.nrOfCpus := 1.0
 BundleKeys.memory := 64.MiB

--- a/src/sbt-test/sbt-conductr-sandbox/scaling/test
+++ b/src/sbt-test/sbt-conductr-sandbox/scaling/test
@@ -2,14 +2,6 @@
 
 > checkContainers1
 
-> sandbox run --nr-of-containers 3
-
-> checkContainers3
-
-> sandbox run --nr-of-containers 2
-
-> checkContainers2
-
 > sandbox stop
 
 > checkContainers0


### PR DESCRIPTION
The user can decide with the option `--nr-of-containers` how many nodes he wants to start in the ConductR cluster. If the user uses the development docker image of ConductR (single node version) then only one docker container will be started and the option `--nr-of-containers` is ignored. Additonally a warning is logged to inform the user that only one node has been started.
