### PR TITLE
WIP - DON'T MERGE: Upgrade to full ConductR version 1.0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ sbt-conductr-sandbox aims to support the running of a Docker-based ConductR clus
 
 ## Usage
 
-The single node version of the ConductR Developer Sandbox is available gratis with registration at Typesafe.com. Please visit the [ConductR Developer](http://www.typesafe.com/product/conductr/developer) page on Typesafe.com for the current image version and licensing information. Use of the ConductR in multi-node mode or for production purposes requires the purchase of Typesafe ConductR. You <strong>must</strong> specify the current `imageVersion which you can obtain from the [ConductR Developer](http://www.typesafe.com/product/conductr/developer) page.
+The version of the ConductR Developer Sandbox is available gratis during development with registration at Typesafe.com. Please visit the [ConductR Developer](http://www.typesafe.com/product/conductr/developer) page on Typesafe.com for the current image version and licensing information. Use of ConductR for production purposes requires the purchase of Typesafe ConductR. You <strong>must</strong> specify the current `imageVersion which you can obtain from the [ConductR Developer](http://www.typesafe.com/product/conductr/developer) page.
 
 ### Docker
 
-To get started quickly, sbt-conductr-sandbox is using a pre-packaged Docker image which has ConductR already installed. In order to use sbt-conductr-sandbox please install [Docker](https://www.docker.com/) with the `docker-machine` CLI.
+To get started quickly, sbt-conductr-sandbox is using a pre-packaged Docker image which has ConductR already installed. In order to use sbt-conductr-sandbox please install [Docker](https://www.docker.com/) and the `docker-machine` CLI.
 
 Verify the installation by entering the following command into the terminal:
 
@@ -64,8 +64,6 @@ By default `sandbox run` is starting a ConductR cluster with one node. Specify t
 ```scala
 sandbox run --nr-of-containers 3
 ```
-
-> The single node version of the ConductR Docker image ignores this option and will always start a ConductR cluster with only one node.
 
 #### Adding / stopping ConductR nodes
 
@@ -166,7 +164,7 @@ Your application defines these settings in the `build.sbt`:
 lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging)
 
 BundleKeys.endpoints := Map("sample-app" -> Endpoint("http", services = Set(uri("http://:9000"))))
-SandboxKeys.imageVersion in Global := "1.0.11"
+SandboxKeys.imageVersion in Global := "1.0.12"
 SandboxKeys.ports in Global := Set(1111)
 SandboxKeys.debugPort := 5095
 ``` 
@@ -178,8 +176,6 @@ Now we create a ConductR cluster with 3 nodes:
 ```
 sandbox run --nr-of-containers 3
 ```
-
-> Note that a cluster with more than one node is only possible with the full version of ConductR. If `SandboxKeys.image` is not overridden the single node version will be used.
 
 These settings result in the following port mapping:
 
@@ -251,6 +247,7 @@ testOptions in IntegrationTest ++= Seq(
     ConductRSandbox.stopConductRs(streams.value.log)
     ConductRSandbox.runConductRs(
       1,
+      Seq.empty,
       Set.empty,
       Map.empty,
       (conductrImage in Global).value,

--- a/sbt-conductr-sandbox-tester/build.sbt
+++ b/sbt-conductr-sandbox-tester/build.sbt
@@ -13,8 +13,8 @@ BundleKeys.roles := Set("bundle-role-1", "bundle-role-2")
 BundleKeys.startCommand := Seq("-Xms1G")
 
 BundleKeys.configurationName := "frontend"
-
+BundleKeys.endpoints := Map("other" -> Endpoint("http", services = Set(URI("http://:9001/other-service"))))
 SandboxKeys.ports in Global := Set(9999)
-SandboxKeys.imageVersion in Global := "1.0.11"
+SandboxKeys.imageVersion in Global := "1.0.12"
 
 SandboxKeys.debugPort := 5432

--- a/src/sbt-test/sbt-conductr-sandbox/basic/test
+++ b/src/sbt-test/sbt-conductr-sandbox/basic/test
@@ -1,4 +1,4 @@
-> 'set SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.11")'
+> 'set SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.12")'
 
 > sandbox run
 

--- a/src/sbt-test/sbt-conductr-sandbox/conductr-roles/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/conductr-roles/build.sbt
@@ -17,18 +17,24 @@ BundleKeys.diskSpace := 10.MB
 BundleKeys.roles := Set("bundle-role-1", "bundle-role-2")
 
 // ConductR sandbox keys
-SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.11")
+SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.12")
 
 val checkConductrRolesByBundle = taskKey[Unit]("Check that the bundle roles are used if no SandboxKeys.conductrRoles is specified.")
 checkConductrRolesByBundle := {
-  val content = "docker inspect --format='{{.Config.Env}}' cond-0".!!
-  val expectedContent = "CONDUCTR_ROLES=bundle-role-1,bundle-role-2"
-  content should include(expectedContent)
+  for (i <- 0 to 2) {
+    val content = s"docker inspect --format='{{.Config.Env}}' cond-$i".!!
+    val expectedContent = "CONDUCTR_ROLES=bundle-role-1,bundle-role-2"
+    content should include(expectedContent)
+  }
 }
 
 val checkConductrRolesBySandboxKey = taskKey[Unit]("Check that the roles declared by SandboxKeys.conductrRoles are used.")
 checkConductrRolesBySandboxKey := {
-  val content = "docker inspect --format='{{.Config.Env}}' cond-0".!!
-  val expectedContent = "CONDUCTR_ROLES=conductr-role-1,conductr-role-2"
-  content should include(expectedContent)
+  for (i <- 0 to 3) {
+    val content = s"docker inspect --format='{{.Config.Env}}' cond-$i".!!
+    val expectedContent =
+      if(i % 2 == 0) "CONDUCTR_ROLES=new-role"
+      else           "CONDUCTR_ROLES=other-role"
+    content should include(expectedContent)
+  }
 }

--- a/src/sbt-test/sbt-conductr-sandbox/conductr-roles/test
+++ b/src/sbt-test/sbt-conductr-sandbox/conductr-roles/test
@@ -1,12 +1,12 @@
-> sandbox run
+> sandbox run --nr-of-containers 3
 
 > checkConductrRolesByBundle
 
 > sandbox stop
 
-> 'set SandboxKeys.conductrRoles in Global := Seq(Set("conductr-role-1", "conductr-role-2"), Set("conductr-role-1"))'
+> 'set SandboxKeys.conductrRoles in Global := Seq(Set("new-role"), Set("other-role"))'
 
-> sandbox run
+> sandbox run --nr-of-containers 4
 
 > checkConductrRolesBySandboxKey
 

--- a/src/sbt-test/sbt-conductr-sandbox/ports-basic/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-basic/build.sbt
@@ -16,26 +16,55 @@ BundleKeys.endpoints := Map("other" -> Endpoint("http", services = Set(URI("http
 // ConductR sandbox keys
 SandboxKeys.ports in Global := Set(1111, 2222)
 SandboxKeys.debugPort := 5432
-SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.11")
+SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.12")
 
 /**
  * Check ports after 'sandbox run' command
  */
 val checkPortsWithRun = taskKey[Unit]("Check that the specified ports are exposed to docker. Debug port should not be exposed.")
 checkPortsWithRun := {
-  val content = s"docker port cond-0".!!
-  val expectedLines = Set(
-    """9004/tcp -> 0.0.0.0:9004""",
-    """9005/tcp -> 0.0.0.0:9005""",
-    """9006/tcp -> 0.0.0.0:9006""",
-    """9200/tcp -> 0.0.0.0:9200""",
-    """9999/tcp -> 0.0.0.0:9999""",
-    """1111/tcp -> 0.0.0.0:1111""",
-    """2222/tcp -> 0.0.0.0:2222""",
-    """9001/tcp -> 0.0.0.0:9001"""
-  )
+  for (i <- 0 to 2) {
+    val content = s"docker port cond-$i".!!
+    val expectedLines = i match {
+      case 0 =>
+        Set(
+          """9004/tcp -> 0.0.0.0:9004""",
+          """9005/tcp -> 0.0.0.0:9005""",
+          """9006/tcp -> 0.0.0.0:9006""",
+          """9200/tcp -> 0.0.0.0:9200""",
+          """9999/tcp -> 0.0.0.0:9999""",
+          """1111/tcp -> 0.0.0.0:1111""",
+          """2222/tcp -> 0.0.0.0:2222""",
+          """9001/tcp -> 0.0.0.0:9001"""
+        )
 
-  expectedLines.foreach(line => content should include(line))
+      case 1 =>
+        Set(
+          """9004/tcp -> 0.0.0.0:9014""",
+          """9005/tcp -> 0.0.0.0:9015""",
+          """9006/tcp -> 0.0.0.0:9016""",
+          """9200/tcp -> 0.0.0.0:9210""",
+          """9999/tcp -> 0.0.0.0:9909""",
+          """1111/tcp -> 0.0.0.0:1121""",
+          """2222/tcp -> 0.0.0.0:2232""",
+          """9001/tcp -> 0.0.0.0:9011"""
+        )
+
+      case 2 =>
+        Set(
+          """9004/tcp -> 0.0.0.0:9024""",
+          """9005/tcp -> 0.0.0.0:9025""",
+          """9006/tcp -> 0.0.0.0:9026""",
+          """9200/tcp -> 0.0.0.0:9220""",
+          """9999/tcp -> 0.0.0.0:9919""",
+          """1111/tcp -> 0.0.0.0:1131""",
+          """2222/tcp -> 0.0.0.0:2242""",
+          """9001/tcp -> 0.0.0.0:9021"""
+        )
+    }
+
+    expectedLines.foreach(line => content should include(line))
+  }
 }
 
 /**
@@ -53,20 +82,51 @@ checkRunStartCommand := {
  */
 val checkPortsWithDebug = taskKey[Unit]("Check that the specified ports are exposed to docker. Debug port should be exposed.")
 checkPortsWithDebug := {
-  val content = s"docker port cond-0".!!
-  val expectedLines = Set(
-    """9004/tcp -> 0.0.0.0:9004""",
-    """9005/tcp -> 0.0.0.0:9005""",
-    """9006/tcp -> 0.0.0.0:9006""",
-    """9200/tcp -> 0.0.0.0:9200""",
-    """9999/tcp -> 0.0.0.0:9999""",
-    """1111/tcp -> 0.0.0.0:1111""",
-    """2222/tcp -> 0.0.0.0:2222""",
-    """5432/tcp -> 0.0.0.0:5432""",
-    """9001/tcp -> 0.0.0.0:9001"""
-  )
+  for (i <- 0 to 2) {
+    val content = s"docker port cond-$i".!!
+    val expectedLines = i match {
+      case 0 =>
+        Set(
+          """9004/tcp -> 0.0.0.0:9004""",
+          """9005/tcp -> 0.0.0.0:9005""",
+          """9006/tcp -> 0.0.0.0:9006""",
+          """9200/tcp -> 0.0.0.0:9200""",
+          """9999/tcp -> 0.0.0.0:9999""",
+          """1111/tcp -> 0.0.0.0:1111""",
+          """2222/tcp -> 0.0.0.0:2222""",
+          """5432/tcp -> 0.0.0.0:5432""",
+          """9001/tcp -> 0.0.0.0:9001"""
+        )
 
-  expectedLines.foreach(line => content should include(line))
+      case 1 =>
+        Set(
+          """9004/tcp -> 0.0.0.0:9014""",
+          """9005/tcp -> 0.0.0.0:9015""",
+          """9006/tcp -> 0.0.0.0:9016""",
+          """9200/tcp -> 0.0.0.0:9210""",
+          """9999/tcp -> 0.0.0.0:9909""",
+          """1111/tcp -> 0.0.0.0:1121""",
+          """2222/tcp -> 0.0.0.0:2232""",
+          """5432/tcp -> 0.0.0.0:5442""",
+          """9001/tcp -> 0.0.0.0:9011"""
+        )
+
+      case 2 =>
+        Set(
+          """9004/tcp -> 0.0.0.0:9024""",
+          """9005/tcp -> 0.0.0.0:9025""",
+          """9006/tcp -> 0.0.0.0:9026""",
+          """9200/tcp -> 0.0.0.0:9220""",
+          """9999/tcp -> 0.0.0.0:9919""",
+          """1111/tcp -> 0.0.0.0:1131""",
+          """2222/tcp -> 0.0.0.0:2242""",
+          """5432/tcp -> 0.0.0.0:5452""",
+          """9001/tcp -> 0.0.0.0:9021"""
+        )
+    }
+
+    expectedLines.foreach(line => content should include(line))
+  }
 }
 
 /**

--- a/src/sbt-test/sbt-conductr-sandbox/ports-basic/test
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-basic/test
@@ -1,4 +1,4 @@
-> sandbox run
+> sandbox run --nr-of-containers 3
 
 > checkPortsWithRun
 
@@ -8,7 +8,9 @@
 
 > clean
 
-> sandbox debug
+> sandbox stop
+
+> sandbox debug --nr-of-containers 3
 
 > checkPortsWithDebug
 

--- a/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/build.sbt
@@ -6,7 +6,7 @@ version := "0.1.0-SNAPSHOT"
 
 // ConductR global keys
 SandboxKeys.ports in Global := Set(1111, 2222)
-SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.11")
+SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.12")
 
 lazy val common = (project in file("modules/common"))
   .settings(

--- a/src/sbt-test/sbt-conductr-sandbox/scaling/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/scaling/build.sbt
@@ -5,25 +5,13 @@ name := "scaling"
 
 version := "0.1.0-SNAPSHOT"
 
-// FIXME: Once the docker image with the full ConductR version is available this test should
-//        execute the following steps in the test file:
-//        > sandbox run
-//        > checkContainers1
-//        > sandbox run --nr-of-containers 3
-//        > checkContainers3
-//        > sandbox run --nr-of-containers 2
-//        > checkContainers2
-//        > sandbox stop
-//        > checkContainers0
-
-
 // ConductR bundle keys
 BundleKeys.nrOfCpus := 1.0
 BundleKeys.memory := 64.MiB
 BundleKeys.diskSpace := 10.MB
 
 // ConductR sandbox keys
-SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.11")
+SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.12")
 
 def resolveRunningContainers = """docker ps --quiet --filter name=cond""".lines_!
 

--- a/src/sbt-test/sbt-conductr-sandbox/scaling/test
+++ b/src/sbt-test/sbt-conductr-sandbox/scaling/test
@@ -2,6 +2,14 @@
 
 > checkContainers1
 
+> sandbox run --nr-of-containers 3
+
+> checkContainers3
+
+> sandbox run --nr-of-containers 2
+
+> checkContainers2
+
 > sandbox stop
 
 > checkContainers0

--- a/src/sbt-test/sbt-conductr-sandbox/with-features/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/with-features/build.sbt
@@ -12,7 +12,7 @@ BundleKeys.nrOfCpus := 1.0
 BundleKeys.memory := 64.MiB
 BundleKeys.diskSpace := 10.MB
 
-SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.11")
+SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.12")
 
 /**
  * Check ports after 'sandbox run' command


### PR DESCRIPTION
- Uses the full ConductR version as docker image (not yet available)
- Uses the new ConductR version 1.0.12 (not yet available)
- Changes tests accordingly to reflect multiple ConductR nodes
- Changes README.md accordingly

This PR need to be tested and merged once ConductR 1.0.12 and the corresponding docker image is available.
