### PR TITLE
Upgrade sbt-conductr to 1.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ ScalariformKeys.preferences := ScalariformKeys.preferences.value
 
 resolvers += Resolver.bintrayRepo("typesafe", "maven-releases")
 
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.2.1")
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.3.0")
 
 releaseSettings
 ReleaseKeys.versionBump := sbtrelease.Version.Bump.Minor


### PR DESCRIPTION
Upgrade to sbt-conductr 1.3.0. The new version of sbt-conductr only supports version 2 of ConductR's REST API. Therefore, it only works with ConductR 1.1+.

This is the reason why the tests on the CI server will fail as long as the docker image of ConductR 1.1.0 is not available. This PR has been smoke tested locally in combination with ConductR 1.1.
