### PR TITLE
Update ConductR Sandbox version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 
 env:
   global:
-    - "HOST_IP=$(/sbin/ifconfig venet0:0 | grep 'inet addr' | awk -F: '{print $2}' | awk '{print $1}')"
+    - "HOST_IP=$(/sbin/ifconfig eth0 | grep 'inet addr' | awk -F: '{print $2}' | awk '{print $1}')"
     - DOCKER_HOST=tcp://$HOST_IP:2375
     - DOCKER_PORT_RANGE=2400:2500
     - SLIRP_PORTS=$(seq 2375 2500)
@@ -13,6 +13,9 @@ before_install:
   - sudo sh -c "apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9"
   - echo exit 101 | sudo tee /usr/sbin/policy-rc.d
   - sudo chmod +x /usr/sbin/policy-rc.d
+  # Hostname need to be set to avoid buffer overlow. Issue: https://github.com/travis-ci/travis-ci/issues/5227
+  - sudo hostname "$(hostname | cut -c1-63)"
+  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
 
 install:
   - sudo apt-get -qqy update

--- a/README.md
+++ b/README.md
@@ -8,9 +8,43 @@ sbt-conductr-sandbox aims to support the running of a Docker-based ConductR clus
 
 > Note that because the sandbox uses Docker, you cannot run bundles that also use Docker - Docker cannot run within Docker! If you have a Docker bundle then we recommend that you setup a VM for development and follow [the regular installation guide of our docs](http://conductr.typesafe.com/); perhaps just for a single node to make your setup a bit easier.
 
-## General Usage
+## Usage
 
-The version of the ConductR Developer Sandbox is available gratis during development with registration at Typesafe.com. Please visit the [ConductR Developer](http://www.typesafe.com/product/conductr/developer) page on Typesafe.com for usage instructions.
+1. Add `sbt-conductr-sandbox` to the `project/plugins.sbt`: 
+
+    ```
+    addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.2.2")
+    ```
+2. Verify that `sbt-bundle` keys have been set. For further information refer to the [sbt-bundle](https://github.com/sbt/sbt-bundle) documentation:
+
+    ```
+    import ByteConversions._
+    BundleKeys.nrOfCpus := 1.0
+    BundleKeys.memory := 64.MiB
+    BundleKeys.diskSpace := 10.MB
+    ```    
+3. Specify the ConductR Developer Sandbox version in the `build.sbt`. This version is available gratis during development with registration at lightbend.com. Please visit the [ConductR Developer](http://www.lightbend.com/product/conductr/developer) page for usage instructions.
+
+    ```
+    SandboxKeys.imageVersion in Global := "YOUR_CONDUCTR_SANDBOX_VERSION"
+    ````
+4. Reload the sbt session:
+
+    ```
+    reload
+    ```    
+       
+The plugin is then enabled automatically for your entire project. Additionally it includes [sbt-conductr](https://github.com/sbt/sbt-conductr) and [sbt-bundle](https://github.com/sbt/sbt-bundle) so these plugins doesn’t need to be added separately. The conduct commands such as conduct info will automatically communicate with the Docker cluster managed by the sandbox. There is no need to set ConductR’s ip address with controlServer manually.
+
+To start the sandbox use the `run` command:
+
+```
+sandbox run
+[info] Running ConductR...
+[info] Running container cond-0 exposing 192.168.59.103:9000...
+```
+
+Checkout the [commands](#Commands) section to see all available sandbox commands.
 
 ## Debugging application in ConductR sandbox
 

--- a/sbt-conductr-sandbox-tester/build.sbt
+++ b/sbt-conductr-sandbox-tester/build.sbt
@@ -15,6 +15,6 @@ BundleKeys.startCommand := Seq("-Xms1G")
 BundleKeys.configurationName := "frontend"
 BundleKeys.endpoints := Map("other" -> Endpoint("http", services = Set(URI("http://:9001/other-service"))))
 SandboxKeys.ports in Global := Set(9999)
-SandboxKeys.imageVersion in Global := "1.0.14"
+SandboxKeys.imageVersion in Global := "1.1.2"
 
 SandboxKeys.debugPort := 5432

--- a/src/sbt-test/sbt-conductr-sandbox/basic/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/basic/build.sbt
@@ -5,8 +5,7 @@ name := "simple-test"
 version := "0.1.0-SNAPSHOT"
 
 val checkConductRIsRunning = taskKey[Unit]("")
+checkConductRIsRunning := s"docker ps -q -f name=cond-".lines_! should have size 1
+
 val checkConductRIsStopped = taskKey[Unit]("")
-
-checkConductRIsRunning := s"docker ps -q -f name=cond-".lines_!.size shouldBe 1
-
-checkConductRIsStopped := s"docker ps -q -f name=cond-".lines_!.size shouldBe 0
+checkConductRIsStopped := """docker ps --quiet --filter name=cond""".lines_! should have size 0

--- a/src/sbt-test/sbt-conductr-sandbox/basic/test
+++ b/src/sbt-test/sbt-conductr-sandbox/basic/test
@@ -1,4 +1,4 @@
-> 'set SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.14")'
+> 'set SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.1.2")'
 
 > sandbox run
 

--- a/src/sbt-test/sbt-conductr-sandbox/conductr-roles/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/conductr-roles/build.sbt
@@ -17,7 +17,7 @@ BundleKeys.diskSpace := 10.MB
 BundleKeys.roles := Set("bundle-role-1", "bundle-role-2")
 
 // ConductR sandbox keys
-SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.14")
+SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.1.2")
 
 val checkConductrRolesByBundle = taskKey[Unit]("Check that the bundle roles are used if no SandboxKeys.conductrRoles is specified.")
 checkConductrRolesByBundle := {
@@ -37,4 +37,9 @@ checkConductrRolesBySandboxKey := {
       else           "CONDUCTR_ROLES=other-role"
     content should include(expectedContent)
   }
+}
+
+val checkConductRIsStopped = taskKey[Unit]("")
+checkConductRIsStopped := {
+  """docker ps --quiet --filter name=cond""".lines_! should have size 0
 }

--- a/src/sbt-test/sbt-conductr-sandbox/conductr-roles/test
+++ b/src/sbt-test/sbt-conductr-sandbox/conductr-roles/test
@@ -11,3 +11,5 @@
 > checkConductrRolesBySandboxKey
 
 > sandbox stop
+
+> checkConductRIsStopped

--- a/src/sbt-test/sbt-conductr-sandbox/ports-basic/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-basic/build.sbt
@@ -16,11 +16,11 @@ BundleKeys.endpoints := Map("other" -> Endpoint("http", services = Set(URI("http
 // ConductR sandbox keys
 SandboxKeys.ports in Global := Set(1111, 2222)
 SandboxKeys.debugPort := 5432
-SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.14")
+SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.1.2")
 
 /**
- * Check ports after 'sandbox run' command
- */
+  * Check ports after 'sandbox run' command
+  */
 val checkPortsWithRun = taskKey[Unit]("Check that the specified ports are exposed to docker. Debug port should not be exposed.")
 checkPortsWithRun := {
   for (i <- 0 to 2) {
@@ -68,8 +68,8 @@ checkPortsWithRun := {
 }
 
 /**
- * Check bundle conf after 'sandbox run' and 'bundle:dist'
- */
+  * Check bundle conf after 'sandbox run' and 'bundle:dist'
+  */
 val checkRunStartCommand = taskKey[Unit]("Check the start-command in bundle.conf. jvm-debug should not be part of it.")
 checkRunStartCommand := {
   val contents = IO.read((target in Bundle).value / "bundle"/ "tmp" / "bundle.conf")
@@ -78,8 +78,8 @@ checkRunStartCommand := {
 }
 
 /**
- * Check ports after 'sandbox debug'
- */
+  * Check ports after 'sandbox debug'
+  */
 val checkPortsWithDebug = taskKey[Unit]("Check that the specified ports are exposed to docker. Debug port should be exposed.")
 checkPortsWithDebug := {
   for (i <- 0 to 2) {
@@ -130,11 +130,16 @@ checkPortsWithDebug := {
 }
 
 /**
- * Check bundle conf after 'sandbox debug' and 'bundle:dist'
- */
+  * Check bundle conf after 'sandbox debug' and 'bundle:dist'
+  */
 val checkDebugStartCommand = taskKey[Unit]("Check the start-command in bundle.conf. jvm-debug should be part of it.")
 checkDebugStartCommand := {
   val contents = IO.read((target in Bundle).value / "bundle" / "tmp" / "bundle.conf")
   val expectedContents = """start-command    = ["ports-basic/bin/ports-basic", "-jvm-debug", "5432", "-J-Xms67108864", "-J-Xmx67108864"]""".stripMargin
   contents should include(expectedContents)
+}
+
+val checkConductRIsStopped = taskKey[Unit]("")
+checkConductRIsStopped := {
+  """docker ps --quiet --filter name=cond""".lines_! should have size 0
 }

--- a/src/sbt-test/sbt-conductr-sandbox/ports-basic/test
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-basic/test
@@ -19,3 +19,5 @@
 > checkDebugStartCommand
 
 > sandbox stop
+
+> checkConductRIsStopped

--- a/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/build.sbt
@@ -6,7 +6,7 @@ version := "0.1.0-SNAPSHOT"
 
 // ConductR global keys
 SandboxKeys.ports in Global := Set(1111, 2222)
-SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.14")
+SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.1.2")
 
 lazy val common = (project in file("modules/common"))
   .settings(
@@ -41,7 +41,6 @@ lazy val backend = (project in file("modules/backend"))
   )
 
 val checkDockerContainers = taskKey[Unit]("Check that the specified ports are exposed to docker.")
-
 checkDockerContainers := {
   // cond-0
   val contentCond0 = s"docker port cond-0".!!
@@ -60,4 +59,9 @@ checkDockerContainers := {
   )
   expectedLinesCond0.foreach(line => contentCond0 should include(line))
 
+}
+
+val checkConductRIsStopped = taskKey[Unit]("")
+checkConductRIsStopped := {
+  """docker ps --quiet --filter name=cond""".lines_! should have size 0
 }

--- a/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/test
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/test
@@ -3,3 +3,5 @@
 > checkDockerContainers
 
 > sandbox stop
+
+> checkConductRIsStopped

--- a/src/sbt-test/sbt-conductr-sandbox/scaling/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/scaling/build.sbt
@@ -11,14 +11,9 @@ BundleKeys.memory := 64.MiB
 BundleKeys.diskSpace := 10.MB
 
 // ConductR sandbox keys
-SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.14")
+SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.1.2")
 
 def resolveRunningContainers = """docker ps --quiet --filter name=cond""".lines_!
-
-val checkContainers0 = taskKey[Unit]("Check that 0 containers are running.")
-checkContainers0 := {
-  resolveRunningContainers should have size 0
-}
 
 val checkContainers1 = taskKey[Unit]("Check that 1 container is running.")
 checkContainers1 := {
@@ -33,4 +28,9 @@ checkContainers2 := {
 val checkContainers3 = taskKey[Unit]("Check that 3 containers are running.")
 checkContainers3 := {
   resolveRunningContainers should have size 3
+}
+
+val checkConductRIsStopped = taskKey[Unit]("")
+checkConductRIsStopped := {
+  resolveRunningContainers should have size 0
 }

--- a/src/sbt-test/sbt-conductr-sandbox/scaling/test
+++ b/src/sbt-test/sbt-conductr-sandbox/scaling/test
@@ -12,4 +12,4 @@
 
 > sandbox stop
 
-> checkContainers0
+> checkConductRIsStopped

--- a/src/sbt-test/sbt-conductr-sandbox/with-features/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/with-features/build.sbt
@@ -12,7 +12,7 @@ BundleKeys.nrOfCpus := 1.0
 BundleKeys.memory := 64.MiB
 BundleKeys.diskSpace := 10.MB
 
-SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.0.14")
+SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "1.1.2")
 
 /**
  * Check ports after 'sandbox run' command
@@ -33,4 +33,9 @@ checkEnvs := {
   val content = "docker inspect --format='{{.Config.Env}}' cond-0".!!
   val expectedContent = "CONDUCTR_FEATURES=visualization,logging"
   content should include(expectedContent)
+}
+
+val checkConductRIsStopped = taskKey[Unit]("")
+checkConductRIsStopped := {
+  """docker ps --quiet --filter name=cond""".lines_! should have size 0
 }

--- a/src/sbt-test/sbt-conductr-sandbox/with-features/test
+++ b/src/sbt-test/sbt-conductr-sandbox/with-features/test
@@ -5,3 +5,5 @@
 > checkEnvs
 
 > sandbox stop
+
+> checkConductRIsStopped

--- a/src/sbt-test/sbt-conductr-sandbox/with-rp-license/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/with-rp-license/build.sbt
@@ -11,3 +11,8 @@ version := "0.1.0-SNAPSHOT"
 BundleKeys.nrOfCpus := 1.0
 BundleKeys.memory := 64.MiB
 BundleKeys.diskSpace := 10.MB
+
+val checkConductRIsStopped = taskKey[Unit]("")
+checkConductRIsStopped := {
+  """docker ps --quiet --filter name=cond""".lines_! should have size 0
+}

--- a/src/sbt-test/sbt-conductr-sandbox/with-rp-license/test
+++ b/src/sbt-test/sbt-conductr-sandbox/with-rp-license/test
@@ -1,3 +1,5 @@
 > sandbox run
 
 > sandbox stop
+
+> checkConductRIsStopped


### PR DESCRIPTION
- Updates the ConductR Sandbox version to 1.1.2
- Updates the README to provide more usage information how to use `sbt-conductr-sandbox`
