### PR TITLE
Do not collect project roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ As a convenience, `sandbox run` and `sandbox debug` is reporting each of the abo
 
 ConductR uses roles to load and scale bundles to the respective nodes. For more information about it please refer to [Managing services documentation](http://conductr.typesafe.com/docs/1.0.x/ManageServices#Roles).
 
-`sbt-conductr-sandbox` automatically collects the bundle roles specified with `BundleKeys.roles` and adds them to each ConductR node. Therefor, by default your bundles can be loaded and scaled to all ConductR nodes. 
-It is also possible to provide a custom role configuration by specifying the `SandboxKeys.conductrRoles` setting: 
+To keep things simple `sbt-conductr-sandbox` ignores roles by default. Therefore, your bundles can be loaded and scaled to all ConductR nodes. 
+To have more fine-grained control of the bundles it is also possible to provide a custom role configuration by specifying the `SandboxKeys.conductrRoles` setting: 
 
 ```scala
 SandboxKeys.conductrRoles in Global := Seq(Set("muchMem", "myDB"))

--- a/src/main/scala/com/typesafe/conductr/sandbox/sbt/ConductRSandbox.scala
+++ b/src/main/scala/com/typesafe/conductr/sandbox/sbt/ConductRSandbox.scala
@@ -283,14 +283,9 @@ object ConductRSandbox extends AutoPlugin {
 
     val debugPorts = state.value.get(WithDebugAttrKey).fold(Set.empty[Int])(_ => debugPort.?.all(filter).value.flatten.toSet)
 
-    val roles = (conductrRoles in Global).value match {
-      case Nil                => Seq((BundleKeys.roles in Bundle).?.map(_.getOrElse(Set.empty)).all(filter).value.reduce(_ ++ _))
-      case conductrRolesValue => conductrRolesValue
-    }
-
     runConductRs(
       nrOfContainers,
-      roles,
+      (conductrRoles in Global).value,
       bundlePorts ++ featurePorts ++ debugPorts ++ (ports in Global).value,
       (envs in Global).value,
       conductrImage,

--- a/src/sbt-test/sbt-conductr-sandbox/conductr-roles/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/conductr-roles/build.sbt
@@ -24,7 +24,7 @@ checkConductrRolesByBundle := {
   for (i <- 0 to 2) {
     val content = s"docker inspect --format='{{.Config.Env}}' cond-$i".!!
     val expectedContent = "CONDUCTR_ROLES=bundle-role-1,bundle-role-2"
-    content should include(expectedContent)
+    content should not include(expectedContent)
   }
 }
 


### PR DESCRIPTION
So far we've collected the roles from the projects to make the life for the user as easy as possible. This resulted in a problem for a Lagom project because here we typically want to load a cassandra bundle which is not part of the project. The cassandra bundle has a different role and therefore this bundle was not loaded when using the sbt-conductr-sandbox.

Now we do not collect and do not set the roles of the projects. As a result ConductR itself will ignore roles completly, i.e. bundles with any kind of roles can be scaled to any node. The user still has the possibility to use roles by setting the `SandboxKeys.conductrRoles` key explicitly. 
